### PR TITLE
Issue #2277: Making Simpletest and the Database config work together.

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -1355,7 +1355,11 @@ class ConfigDatabaseStorage implements ConfigStorageInterface {
    * @throws ConfigStorageException
    */
   public function initializeStorage() {
-    if (!db_table_exists($this->table, array('target' => $this->database))) {
+    // db_table_exists() does not prefix our tables, so we have to do it
+    // manually when we do this check.
+    $connection_info = Database::getConnectionInfo($this->database);
+    $prefix = $connection_info[$this->database]['prefix']['default'];
+    if (!db_table_exists($prefix . $this->table)) {
       try {
         db_create_table($this->table, $this->schema($this->table));
       }

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1707,6 +1707,17 @@ class BackdropWebTestCase extends BackdropTestCase {
       return FALSE;
     }
 
+    // This has to happen before any config changes are made to ensure that the
+    // database tables from the test cache exist.
+    $use_cache = $this->useCache();
+
+    if (!$use_cache) {
+      // Force config storage to initialize so that it will make sure the tables
+      // and folders we need exist.
+      $storage = config_get_config_storage();
+      $storage->initializeStorage();
+    }
+
     // Preset the 'install_profile' system variable, so the first call into
     // system_rebuild_module_data() (in backdrop_install_system()) will register
     // the test's profile as a module. Without this, the installation profile of
@@ -1715,7 +1726,6 @@ class BackdropWebTestCase extends BackdropTestCase {
     config_install_default_config('system');
     config_set('system.core', 'install_profile', $this->profile);
 
-    $use_cache = $this->useCache();
     if (!$use_cache) {
       // Perform the actual Backdrop installation.
       include_once BACKDROP_ROOT . '/core/includes/install.inc';

--- a/core/modules/simpletest/backdrop_web_test_case_cache.php
+++ b/core/modules/simpletest/backdrop_web_test_case_cache.php
@@ -75,6 +75,11 @@ class BackdropWebTestCaseCache extends BackdropWebTestCase {
       return FALSE;
     }
 
+    // Force config storage to initialize so that it will make sure the tables
+    // and folders we need exist.
+    $storage = config_get_config_storage();
+    $storage->initializeStorage();
+
     // Preset the 'install_profile' system variable, so the first call into
     // system_rebuild_module_data() (in backdrop_install_system()) will register
     // the test's profile as a module. Without this, the installation profile of


### PR DESCRIPTION
@quicksketch This should allow the tests to run with config stored in the database. 